### PR TITLE
Open modal when collapsed layout is clicked

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,6 +63,10 @@
 			
 			$layout.find('> .acf-fc-layout-handle').off('click');
 			$layout.find('> .acf-fc-layout-controls > a.-collapse').remove();
+			
+			// Open modal when the collapsed layout is clicked
+
+			$layout.find('> .acf-fc-layout-handle').on('click', ACFFCM.open);
 					
 			// Edit button
 			


### PR DESCRIPTION
This change allows the entire collapsed layout to open the modal when clicked, creating a bigger and more intuitive hit area.

All other functionality such as drag and drop, add new layout and remove layout is preserved.