### PR TITLE
Hightlight layout when modal is closed

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,8 +86,7 @@
 			
 			$layout.find('> .acf-fc-modal-title').html(caption).append(a);
 			$layout.addClass('-modal');
-			$layout.removeClass('-highlight-closed');
-
+			
 			ACFFCM.modals.push($layout);
 			
 			ACFFCM.overlay(true);
@@ -109,6 +108,10 @@
 			$layout.find('> .acf-fc-modal-title').html(' ');
 			$layout.removeClass('-modal').css('visibility', '');
 			$layout.addClass('-highlight-closed');
+
+			setTimeout(function() {
+				$layout.removeClass('-highlight-closed');				
+			}, 750);
 						
 			ACFFCM.overlay(false);
 

--- a/script.js
+++ b/script.js
@@ -86,7 +86,8 @@
 			
 			$layout.find('> .acf-fc-modal-title').html(caption).append(a);
 			$layout.addClass('-modal');
-			
+			$layout.removeClass('-highlight-closed');
+
 			ACFFCM.modals.push($layout);
 			
 			ACFFCM.overlay(true);
@@ -107,6 +108,7 @@
 
 			$layout.find('> .acf-fc-modal-title').html(' ');
 			$layout.removeClass('-modal').css('visibility', '');
+			$layout.addClass('-highlight-closed');
 						
 			ACFFCM.overlay(false);
 

--- a/style.css
+++ b/style.css
@@ -158,3 +158,13 @@ body.acf-modal-open {
 .acf-flexible-content .layout.-modal.-animate {
 	animation: fcModalSlide .2s ease-out;
 }
+
+@keyframes highlightClosed {
+	0% { background: #fff; }
+	30% { background: rgba(0, 133, 186, 0.3); } /* WordPress blue, faded */
+	100% { background: #fff; }		
+}
+
+.acf-flexible-content .layout.-highlight-closed {
+	animation: highlightClosed .65s .1s ease-out;
+}


### PR DESCRIPTION
When a layout is closed, it will briefly flash blue in the list of layouts.

This helps to reorient the user to the layout that has reappeared and makes it easier to find your place in pages with large numbers of layouts.