### PR TITLE
Stop modal opening when links in handle clicked

### DIFF
--- a/script.js
+++ b/script.js
@@ -66,7 +66,12 @@
 			
 			// Open modal when the collapsed layout is clicked
 
-			$layout.find('> .acf-fc-layout-handle').on('click', ACFFCM.open);
+			$layout.find('> .acf-fc-layout-handle').on('click', function(event) {
+				// Don't open modal when clicking on links within the handle
+				if ( event.target.tagName.toLowerCase() !== 'a' ) {
+					ACFFCM.open.call(this);
+				}
+			});
 					
 			// Edit button
 			


### PR DESCRIPTION
Related to my previous PR #8 

When clicking on any links within the layout handle, specifically with `target="_blank"`, the modal is still opened.

Links can be created when using the ACF hook [acf/fields/flexible_content/layout_title](https://www.advancedcustomfields.com/resources/acf-fields-flexible_content-layout_title/) as mentioned in the readme.md. This could be creating a quick edit link for a post object field or a link to an external URL for a link field.

`toLowerCase()` is used to ensure standardisation between different formats.